### PR TITLE
Prettify status! (and refactor conf makers)

### DIFF
--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -191,3 +191,4 @@ func ExportAppendChain(blockchain *core.BlockChain, fn string, first uint64, las
 	glog.Infoln("Exported blockchain to ", fn)
 	return nil
 }
+

--- a/cmd/geth/cmd.go
+++ b/cmd/geth/cmd.go
@@ -29,6 +29,8 @@ import (
 	"github.com/ethereumproject/go-ethereum/logger/glog"
 	"github.com/ethereumproject/go-ethereum/node"
 	"github.com/ethereumproject/go-ethereum/rlp"
+	"github.com/ethereumproject/go-ethereum/eth"
+	"strconv"
 )
 
 const (
@@ -192,3 +194,78 @@ func ExportAppendChain(blockchain *core.BlockChain, fn string, first uint64, las
 	return nil
 }
 
+func withLineBreak(s string) string {
+	return s + "\n"
+}
+
+func colorGreen(s string) string {
+	return "\x1b[32m" + s + "\x1b[39m"
+}
+
+func colorBlue(s string) string {
+	return "\x1b[36m" + s + "\x1b[39m"
+}
+
+// For use by 'status' command.
+// These are one of doing it, with each key/val per line and some appropriate indentations to signal grouping/parentage.
+// ... But there might be a more elegant way using columns and stuff. VeryPretty?
+func logSufficientChainConfigPretty(config *core.SufficientChainConfig) (s string) {
+	// ID(not ChainID, but ChainID')
+	// Name
+	// Genesis (dump)
+	// ChainConfig
+	// 	Forks
+	// 		Features
+	//			Options
+	//		RequiredHash
+	//	BadHashes
+	s += withLineBreak("Name: " + colorGreen(config.Name))
+	return s
+}
+
+func logEthConfigPretty(ethConfig *eth.Config) (s string) {
+	// NetworkID
+	// FastSync?
+	// BlockChainVersion
+	// DatabaseCache
+	// DatabaseHandles
+	// NatSpec?
+	// AutoDAG?
+	// PowTest?
+	// PowShared?
+	// Account Manager
+	//	Number of accounts
+	//	Keystore
+	//		Dir
+	//		ScryptN
+	//		ScryptP
+	// Etherbase (if set)
+	// GasPrice
+	// MinerThreads
+	s += withLineBreak("Network ID: " + colorGreen(strconv.Itoa(ethConfig.NetworkId)))
+	return s
+}
+
+func logStackConfigPretty(stackConfig *node.Config) (s string) {
+	// Name
+	// Datadir
+	// IPCPath
+	// PrivateKey?
+	// Discovery?
+	// BoostrapNodes
+	//	Enode
+	// ListenAddr
+	// NAT
+	// MaxPeers
+	// MaxPendingPeers
+	// HTTPHost
+	// HTTPPort
+	// HTTPCors
+	// HTTPModules[]
+	// WSHost
+	// WSPort
+	// WSOrigins
+	// WSModules[]
+	s += withLineBreak("Name: " + colorGreen(stackConfig.Name))
+	return s
+}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -264,8 +264,21 @@ func geth(ctx *cli.Context) error {
 }
 
 func status(ctx *cli.Context) error {
-	node := MakeSystemNode(Version, ctx)
-	glog.V(logger.Info).Info(spew.Sdump(node))
+	// Makes sufficient configuration from JSON file or DB pending flags.
+	// Delegates flag usage.
+	config := mustMakeSufficientChainConfig(ctx)
+
+	// Configure the Ethereum service
+	ethConf := mustMakeEthConf(ctx, config)
+
+	// Configure node's service container.
+	name := makeNodeName(Version, ctx)
+	stackConf, _ := mustMakeStackConf(ctx, name, config, ethConf)
+
+
+	glog.V(logger.Info).Info(spew.Sdump(config))
+	glog.V(logger.Info).Info(spew.Sdump(ethConf))
+	glog.V(logger.Info).Info(spew.Sdump(stackConf))
 	return nil
 }
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -40,7 +40,6 @@ import (
 	"github.com/ethereumproject/go-ethereum/metrics"
 	"github.com/ethereumproject/go-ethereum/node"
 
-	"github.com/davecgh/go-spew/spew"
 )
 
 // Version is the application revision identifier. It can be set with the linker
@@ -275,10 +274,18 @@ func status(ctx *cli.Context) error {
 	name := makeNodeName(Version, ctx)
 	stackConf, _ := mustMakeStackConf(ctx, name, config, ethConf)
 
+	glog.V(logger.Info).Info(glog.Separator("-"))
+	glog.V(logger.Info).Info(colorBlue("* Chain Configuration"))
+	glog.V(logger.Info).Info(logSufficientChainConfigPretty(config))
 
-	glog.V(logger.Info).Info(spew.Sdump(config))
-	glog.V(logger.Info).Info(spew.Sdump(ethConf))
-	glog.V(logger.Info).Info(spew.Sdump(stackConf))
+	glog.V(logger.Info).Info(glog.Separator("-"))
+	glog.V(logger.Info).Info(colorBlue("* Ethereum Configuration"))
+	glog.V(logger.Info).Info(logEthConfigPretty(ethConf))
+
+	glog.V(logger.Info).Info(glog.Separator("-"))
+	glog.V(logger.Info).Info(colorBlue("* Node Configuration"))
+	glog.V(logger.Info).Info(logStackConfigPretty(stackConf))
+
 	return nil
 }
 


### PR DESCRIPTION
Check this out, @odeke-em. I refactored the configuration makers so we don't have to start the node and can still get access to all 3 major configuration structs. 

Wondering about visual displays of information w/r/t bare-bones stdout (hacker friendly) and/vs human readable. The colors might be overkill...